### PR TITLE
ARP-2952: remove length check when decoding shared keys/values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "newsmile"
-version = "1.1.4"
+version = "1.1.5"
 authors = [
   { name="Laurent Mornet", email="laurent.mornet@gmail.com" },
 ]

--- a/src/newsmile/decoder.py
+++ b/src/newsmile/decoder.py
@@ -39,19 +39,17 @@ class SmileDecoder:
         '''
         Save shared key in dedicated buffer
         '''
-        if len(key) <= 64:
-            if len(self._shared_keys) >= 1024:
-                self._shared_keys = []
-            self._shared_keys.append(key)
+        if len(self._shared_keys) >= 1024:
+            self._shared_keys = []
+        self._shared_keys.append(key)
 
     def _set_shared_value(self, value):
         '''
         Save shared value in dedicated buffer
         '''
-        if len(value) <= 64:
-            if len(self._shared_values) >= 1024:
-                self._shared_values = []
-            self._shared_values.append(value)
+        if len(self._shared_values) >= 1024:
+            self._shared_values = []
+        self._shared_values.append(value)
 
     @classmethod
     def _unzigzag(cls, value, mask = None):


### PR DESCRIPTION
Removes length check when deciding to store shared keys.  This check is performed during encoding, but shouldn't be performed during decode.  

I checked several other SMILE decoder implementations, and they don't perform this check.